### PR TITLE
fix title footer color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -20,7 +20,7 @@
   --ifm-color-emphasis-200: #e5e7eb;
   --ifm-color-gray-800: #e5e7eb;
   --ifm-background-color: #ffffff;
-  --ifm-footer-title-color: #202327;
+  --ifm-footer-title-color: var(--band-neutral-900);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --band-neutral-000: #ffffff;
   --band-neutral-100: #f3f4f6;
@@ -35,9 +35,10 @@
   --ifm-tabs-padding-vertical: 10px;
   --ifm-menu-link-sublist-icon: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NDggNTEyIj48IS0tISBGb250IEF3ZXNvbWUgUHJvIDYuNC4wIGJ5IEBmb250YXdlc29tZSAtIGh0dHBzOi8vZm9udGF3ZXNvbWUuY29tIExpY2Vuc2UgLSBodHRwczovL2ZvbnRhd2Vzb21lLmNvbS9saWNlbnNlIChDb21tZXJjaWFsIExpY2Vuc2UpIENvcHlyaWdodCAyMDIzIEZvbnRpY29ucywgSW5jLiAtLT48cGF0aCBkPSJNMjAxLjQgMTM3LjRjMTIuNS0xMi41IDMyLjgtMTIuNSA0NS4zIDBsMTYwIDE2MGMxMi41IDEyLjUgMTIuNSAzMi44IDAgNDUuM3MtMzIuOCAxMi41LTQ1LjMgMEwyMjQgMjA1LjMgODYuNiAzNDIuNmMtMTIuNSAxMi41LTMyLjggMTIuNS00NS4zIDBzLTEyLjUtMzIuOCAwLTQ1LjNsMTYwLTE2MHoiLz48L3N2Zz4=);
   --ifm-blockquote-color: var(--band-neutral-600);
-  --ifm-menu-link-sublist-icon-filter: invert(100%) sepia(94%) saturate(17%)
-  hue-rotate(223deg) brightness(0%) contrast(98%);
-  --ifm-breadcrumb-separator-filter: invert(64%) sepia(11%) saturate(0%) hue-rotate(149deg) brightness(99%) contrast(95%);
+  --ifm-menu-link-sublist-icon-filter: invert(100%) sepia(94%) saturate(17%) hue-rotate(223deg)
+    brightness(0%) contrast(98%);
+  --ifm-breadcrumb-separator-filter: invert(64%) sepia(11%) saturate(0%) hue-rotate(149deg)
+    brightness(99%) contrast(95%);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -67,9 +68,8 @@
   --band-neutral-700: #a0aec0;
   --band-neutral-800: #cbd5e0;
   --band-neutral-900: var(--ifm-color-white);
-  --ifm-menu-link-sublist-icon-filter: invert(90%) sepia(94%) saturate(17%)
-  hue-rotate(223deg) brightness(90%) contrast(98%);
-  
+  --ifm-menu-link-sublist-icon-filter: invert(90%) sepia(94%) saturate(17%) hue-rotate(223deg)
+    brightness(90%) contrast(98%);
 }
 
 html {
@@ -187,10 +187,17 @@ svg {
   padding-bottom: 10px;
 }
 
-.menu ul.menu__list > li.menu__list-item:not(.menu__list-item--collapsed) > div > .menu__link--sublist-caret::after {
+.menu
+  ul.menu__list
+  > li.menu__list-item:not(.menu__list-item--collapsed)
+  > div
+  > .menu__link--sublist-caret::after {
   filter: var(--ifm-menu-link-sublist-icon-filter);
 }
 
-.menu ul.menu__list > li.theme-doc-sidebar-item-category-level-1.menu__list-item:not(.menu__list-item--collapsed) .menu__list {
+.menu
+  ul.menu__list
+  > li.theme-doc-sidebar-item-category-level-1.menu__list-item:not(.menu__list-item--collapsed)
+  .menu__list {
   background-color: var(--band-neutral-100);
 }


### PR DESCRIPTION
Looking at the CSS file, I can see why using var(--band-neutral-900)  fixes the issue:

  1. Before: The hardcoded #202327 couldn't be overridden by the dark
  mode selector
  2. After: var(--band-neutral-900) is a CSS custom property that gets
  redefined in dark mode scope, so it automatically resolves to the
  correct color for each theme

  When you use a CSS variable instead of a hardcoded value, the variable
   can be redefined in different scopes (like [data-theme='dark']),
  making the color dynamic based on the current theme.
