### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -75,6 +75,7 @@ const config: Config = {
     },
   ],
   plugins: [
+    'docusaurus-plugin-copy-page-button',
     require.resolve('docusaurus-plugin-image-zoom'),
     // only enabled on production
     // [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@mdx-js/react": "^3.1.0",
     "@types/node": "^22.10.7",
     "clsx": "^1.2.1",
+    "docusaurus-plugin-copy-page-button": "^0.8.3",
     "docusaurus-plugin-image-zoom": "^1.0.1",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4051,6 +4051,11 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+docusaurus-plugin-copy-page-button@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.8.3.tgz#fbe3f6d83bf737d9fc9510fe98b38952d19e7e4d"
+  integrity sha512-2/k4H/ePsuZUVv5S91XC2zhnIWLufHzEPTdo/6jYcvonQqHKcLK9vfOp24L5qwMO16VGhHRIEYcEVrXOshxaBw==
+
 docusaurus-plugin-image-zoom@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-1.0.1.tgz#17afec39f2e630cac50a4ed3a8bbdad8d0aa8b9d"


### PR DESCRIPTION
This PR
- adds docusaurus-plugin-copy-page-button to package.json
- adds the plugin string to plugins in docusaurus.config.ts
- puts a "Copy page" button in the docs sidebar — exports current page as clean markdown
- adds one-click "Open in Claude / ChatGPT / Gemini" actions that prefill the markdown

why useful for BandChain specifically:
the develop/ and node-validators/ sections are heavy on per-page integration detail — oracle scripts, data sources, OBI encoding, running and joining a node. the usual flow for someone building against Band or standing up a validator is reading a page → wanting to drop just that page into an LLM to scaffold the integration or debug a node setup. this saves the select-and-clean step.

zero config, auto-injects into the TOC sidebar, theme-aware.

shipping on React Native, Redux Toolkit, Puppeteer, pnpm, PlayCanvas, Arbitrum, Cardano, Sui, Nillion, Flare, Kaia, and ~20 other docs sites. listed on the Docusaurus community plugins page.

happy to close/rebase if not a fit
- repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
